### PR TITLE
Adds lograge gem for condensed logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,4 +31,5 @@ group :production do
   gem "pg"
   gem "newrelic_rpm"
   gem "honeybadger"
+  gem "lograge"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,10 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.0)
+    lograge (0.2.2)
+      actionpack (>= 3)
+      activesupport (>= 3)
+      railties (>= 3)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -165,6 +169,7 @@ DEPENDENCIES
   honeybadger
   jbuilder (~> 1.2)
   jquery-rails
+  lograge
   newrelic_rpm
   pg
   rails (~> 4.0.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,6 +4,9 @@ G5PhoneNumberService::Application.configure do
   # Code is not reloaded between requests.
   config.cache_classes = true
 
+ # Adds condensed logging
+  config.lograge.enabled = true
+
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both thread web servers
   # and those relying on copy on write to perform better.


### PR DESCRIPTION
Pivotal Tracker story: https://www.pivotaltracker.com/story/show/66568320

Have Papertrail filter noise, such as requests for static assets. http://blog.papertrailapp.com/more-signal-less-noise-with-simple-free-log-filtering/

Denser logging. Many Web frameworks (including Rails) are very verbose. Here's how to make Rails logs more useful and denser in 2 minutes. http://help.papertrailapp.com/kb/configuration/controlling-verbosity

Related:
https://github.com/g5search/g5-content-management-system/pull/238
https://github.com/g5search/g5-client-app-creator/pull/26
https://github.com/G5/g5-hub/pull/24
https://github.com/G5/g5-layout-garden/pull/16
https://github.com/g5search/g5-theme-garden/pull/67
https://github.com/G5/g5-widget-garden/pull/197
https://github.com/G5/g5-pricing-and-availability-service/pull/30
https://github.com/G5/g5-configurator/pull/23
