### PR TITLE
Add in rack-cors so we can check status from the hub

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "turbolinks"
 gem "jbuilder", "~> 1.2"
 gem "microformats2"
 gem 'g5_updatable', '~> 0.5.1'
+gem 'rack-cors', :require => 'rack/cors'
 gem 'g5_authenticatable'
 gem "pg"
 gem 'g5_heroku_app_name_formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rack (1.5.5)
+    rack-cors (0.4.0)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.1.12)
@@ -304,6 +305,7 @@ DEPENDENCIES
   pg
   poltergeist
   pry
+  rack-cors
   rails (~> 4.1.11)
   rails_12factor
   rspec-rails (~> 2.14.0)
@@ -314,3 +316,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   webmock
+
+BUNDLED WITH
+   1.10.4

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,12 @@ module G5PhoneNumberService
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+
+    config.middleware.insert_before 0, "Rack::Cors" do
+      allow do
+        origins '*'
+        resource '*', :headers => :any, :methods => [:get, :post, :options]
+      end
+    end
   end
 end


### PR DESCRIPTION
The rack-cors gem is required in order for the g5 updatable health check to work correctly from the hub.