### PR TITLE
Standardize on PST

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,7 +15,7 @@ module G5PhoneNumberService
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'Pacific Time (US & Canada)'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]


### PR DESCRIPTION
Use the same timezone as all other apps in the constellation so our updatable health status check lines up.