### PR TITLE
Add internal branded name

### DIFF
--- a/app/views/clients/show.html.erb
+++ b/app/views/clients/show.html.erb
@@ -34,7 +34,7 @@
           <%= location.urn %>
         </td>
         <td class="p-name" id="name--<%= location.name %>">
-          <%= location.name %>
+          <%= location.name %><br/>
           <em><%= location.internal_branded_name %></em>
         </td>
         <td class="p-tel p-tel-default" id="default_number--<%= fetch_phone_number("default", location.phone_numbers) %>">

--- a/app/views/clients/show.html.erb
+++ b/app/views/clients/show.html.erb
@@ -35,6 +35,7 @@
         </td>
         <td class="p-name" id="name--<%= location.name %>">
           <%= location.name %>
+          <em><%= location.internal_branded_name %></em>
         </td>
         <td class="p-tel p-tel-default" id="default_number--<%= fetch_phone_number("default", location.phone_numbers) %>">
           <%= fetch_phone_number("default", location.phone_numbers) %>

--- a/app/views/clients/show.html.erb
+++ b/app/views/clients/show.html.erb
@@ -35,7 +35,7 @@
         </td>
         <td class="p-name" id="name--<%= location.name %>">
           <%= location.name %><br/>
-          <em><%= location.internal_branded_name %></em>
+          <em><%= location.try(:internal_branded_name) %></em>
         </td>
         <td class="p-tel p-tel-default" id="default_number--<%= fetch_phone_number("default", location.phone_numbers) %>">
           <%= fetch_phone_number("default", location.phone_numbers) %>

--- a/spec/controllers/clients_controller_spec.rb
+++ b/spec/controllers/clients_controller_spec.rb
@@ -29,9 +29,10 @@ describe ClientsController do
   describe "GET 'show'" do
     render_views
     before do
+
       @test_client = G5Updatable::Client.create! "urn" => "g5-cl-6cx7rin-gigity", "name" => "Gigity", uid: "blah-blah-blah"
-      @loc1 = Location.create! urn: "g5-cl-6cx7aaa-gigity-1", uid: "uid-1", name: "Gigity 1", client_uid: @test_client.uid
-      @loc2 = Location.create! urn: "g5-cl-6cx7bbb-gigity-2", uid: "uid-2", name: "Gigity 2", client_uid: @test_client.uid
+      @loc1 = Location.create! urn: "g5-cl-6cx7aaa-gigity-1", uid: "uid-1", name: "Gigity 1", client_uid: @test_client.uid, properties: {internal_branded_name: "Quagmire 1"}
+      @loc2 = Location.create! urn: "g5-cl-6cx7bbb-gigity-2", uid: "uid-2", name: "Gigity 2", client_uid: @test_client.uid, properties: {internal_branded_name: "Quagmire 2"}
       @number1 = PhoneNumber.create! number: "1234567890", number_kind: "default", location_id: @loc1.id
       @number2 = PhoneNumber.create! number: "9876543210", number_kind: "mobile",  location_id: @loc2.id
       @number3 = PpcNumber.create! number: "1111111111", cpm_code: "google",  location_id: @loc1.id


### PR DESCRIPTION
Adds the internal branded name to locations -- 

Currently on clients with identically named locations, the only way to distinguish between them in the CPNS is the URN, which is ugly and hard to do. This will make it easier. 

Had to alter the specs to pass. 

