### PR TITLE
404 instead of error on bad json request

### DIFF
--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -8,7 +8,7 @@ class ClientsController < ApplicationController
   end
 
   def show
-    @client = G5Updatable::Client.find_by_urn(params[:id])
+    @client = G5Updatable::Client.find_by_urn(params[:id]) || (not_found and return)
 
     @locations = Location.includes(:phone_numbers, :ppc_numbers).where(client_uid: @client.uid).order(:name)
 
@@ -20,4 +20,9 @@ class ClientsController < ApplicationController
     end
   end
 
+  private
+
+  def not_found
+    render text: "404 not found", status: 404
+  end
 end

--- a/spec/controllers/clients_controller_spec.rb
+++ b/spec/controllers/clients_controller_spec.rb
@@ -79,6 +79,13 @@ describe ClientsController do
         expect(@json_feed['locations'].first['google']).to eq(@number3.number)
       end
     end
+
+    context "bad json requests" do
+      it "returns a 404 when passed a bad URN" do
+        get :show, id: "some-janky-urn", format: :json
+        expect(response.status).to eq(404)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
stop throwing errors when a request comes through with a bad URN